### PR TITLE
Fix set user login to the session on correct login

### DIFF
--- a/flask_login_openerp/__init__.py
+++ b/flask_login_openerp/__init__.py
@@ -95,6 +95,7 @@ class OpenERPLogin(LoginManager):
                 user.id = user_id
                 login_user(user)
                 session['openerp_user_id'] = user_id
+                session['openerp_user'] = form.login.data
                 session['openerp_password'] = form.password.data
                 return redirect(request.args.get("next") or url_for('index'))
             else:


### PR DESCRIPTION
If we don't setup the user name in the `session` then `erppeek` will use `password` from the login form and the `user` as the `DEFAULT_USER`

https://github.com/gisce/flask-erppeek/blob/0b249a5d1f7da353eb7941bbdb3ed8f7ebdfb242/flask_erppeek/openerp.py#L92