### PR TITLE
Fix user auth and logout

### DIFF
--- a/flask_login_openerp/__init__.py
+++ b/flask_login_openerp/__init__.py
@@ -77,8 +77,10 @@ class OpenERPLogin(LoginManager):
             del session['openerp_user']
         if self.logout_redirect_view:
             response = redirect(url_for(self.logout_redirect_view))
-            response.headers['Cache-Control'] = 'no-cache, no-store, ' \
-                                                'must-revalidate'
+            response.headers['Cache-Control'] = ', '.join(['no-cache',
+                                                           'no-store',
+                                                           'must-revalidate'
+                                                           ])
             response.headers['Pragma'] = 'no-cache'
             response.headers['X-UA-Compatible'] = 'IE=Edge,chrome=1'
             return response

--- a/flask_login_openerp/__init__.py
+++ b/flask_login_openerp/__init__.py
@@ -77,10 +77,9 @@ class OpenERPLogin(LoginManager):
             del session['openerp_user']
         if self.logout_redirect_view:
             response = redirect(url_for(self.logout_redirect_view))
-            response.headers['Cache-Control'] = ', '.join(['no-cache',
-                                                           'no-store',
-                                                           'must-revalidate'
-                                                           ])
+            response.headers['Cache-Control'] = ', '.join([
+                'no-cache','no-store','must-revalidate'
+            ])
             response.headers['Pragma'] = 'no-cache'
             response.headers['X-UA-Compatible'] = 'IE=Edge,chrome=1'
             return response

--- a/flask_login_openerp/__init__.py
+++ b/flask_login_openerp/__init__.py
@@ -12,7 +12,10 @@ from flask_erppeek import get_object
 
 class OpenERPUser(UserMixin):
     def is_authenticated(self):
-        return True
+        if 'openerp_user_id' in session:
+            return True
+        else:
+            return False
 
 
 class LoginForm(Form):

--- a/flask_login_openerp/__init__.py
+++ b/flask_login_openerp/__init__.py
@@ -73,15 +73,22 @@ class OpenERPLogin(LoginManager):
             flash("You have been logout", "info")
         if 'openerp_password' in session:
             del session['openerp_password']
+        if 'openerp_user' in session:
+            del session['openerp_user']
         if self.logout_redirect_view:
-            return redirect(url_for(self.logout_redirect_view))
+            response = redirect(url_for(self.logout_redirect_view))
+            response.headers['Cache-Control'] = 'no-cache, no-store, ' \
+                                                'must-revalidate'
+            response.headers['Pragma'] = 'no-cache'
+            response.headers['X-UA-Compatible'] = 'IE=Edge,chrome=1'
+            return response
         return "Log out!"
 
     def login(self):
         obj = get_object('res.users')
         user_name = g.openerp_cnx.user
         user_id = obj.search([('login', '=', user_name)])
-        company= obj.browse(user_id[0]).company_id
+        company = obj.browse(user_id[0]).company_id
         company_logo = company.logo
         company_name = company.name
 


### PR DESCRIPTION
* Force no-cache to avoid caching when the logout is made. Without this code, the browser will cache the content to display and skip the logout code. If the logout code is skiped the user session remains and it's possible access to the webgis without enter the credentials.

* Fixed the is_authenticated method because it was always set to true. Now checks if the session have the openerp_user_id to ensure that the user is authenticated.