### PR TITLE
Use login method instead of searching by user/password

### DIFF
--- a/flask_login_openerp/__init__.py
+++ b/flask_login_openerp/__init__.py
@@ -106,7 +106,7 @@ class OpenERPLogin(LoginManager):
                 user_id = None
 
             if user_id:
-                user_id = user_id[0]
+                user_id = obj.search([('login', '=', form.login.data)])[0]
                 flash("Login successful", "success")
                 user = OpenERPUser()
                 user.id = user_id

--- a/flask_login_openerp/__init__.py
+++ b/flask_login_openerp/__init__.py
@@ -100,10 +100,11 @@ class OpenERPLogin(LoginManager):
         else:
             form = LoginForm()
         if form.validate_on_submit():
-            user_id = obj.search([
-                ('login', '=', form.login.data),
-                ('password', '=', form.password.data)
-            ])
+            try:
+                g.openerp_cnx.login(form.login.data, form.password.data)
+            except Exception:
+                user_id = None
+
             if user_id:
                 user_id = user_id[0]
                 flash("Login successful", "success")


### PR DESCRIPTION
If the password is encrypted in the database due using `base_crypt` module, we can't check the login searching by user and password in the database.

Instead of this we use the `login` method of ErpPeek Client.